### PR TITLE
Correctly set PATH_INFO environment variable for FastCGI applications

### DIFF
--- a/httpd/server_fcgi.c
+++ b/httpd/server_fcgi.c
@@ -210,6 +210,13 @@ server_fcgi(struct httpd *env, struct client *clt)
 		}
 		script[scriptlen] = '\0';
 	}
+	else {
+		if (fcgi_add_param(&param, "PATH_INFO", "", clt) == -1) {
+			errstr = "failed to encode param";
+			goto fail;
+		}
+	}
+
 
 	/*
 	 * calculate length of http SCRIPT_NAME:


### PR DESCRIPTION
According to RFC 3875 PATH_INFO should either contain a full path or be empty.

Currently, it is not set at all when there is nothing to set. This seems to cause problems with some FastCGI applications (in my case a Flask/Python application through uWSGI).

The [CGI RFC](https://www.ietf.org/rfc/rfc3875) declares the grammar for PATH_INFO like so:
```
PATH_INFO = "" | ( "/" path )
path      = lsegment *( "/" lsegment )
lsegment  = *lchar
lchar     = <any TEXT or CTL except "/">
```
However, I am not sure if it is to be taken that literally.

Nevertheless, setting PATH_INFO to "" seems to fix this problem. A quick look at [lighttpd](https://github.com/lighttpd/lighttpd1.4/blob/master/src/mod_fastcgi.c#L1926) shows that they seem to do it this way, as well.