### PR TITLE
Ensure leading slash if path component is a directory

### DIFF
--- a/httpd/httpd.c
+++ b/httpd/httpd.c
@@ -722,8 +722,12 @@ path_info(char *path)
 		*p = ch;
 
 		/* Break if the initial path component was found */
-		if (ret == 0)
+		if (ret == 0) {
+			/* ensure leading / if path component is a directory */
+			if (S_ISDIR(st.st_mode))
+				return (p - start - 1);
 			break;
+		}
 	}
 
 	return (p - start);


### PR DESCRIPTION
This fixes Werkzeug-based and possibly other applications using `PATH_INFO`.

CGI [RFC3875](https://tools.ietf.org/html/rfc3875#section-4.1.5) and [PEP3333](https://www.python.org/dev/peps/pep-3333/#environ-variables) state that `PATH_INFO` can be empty ("") or "/" for application root paths, but some applications (Werkzeug/Flask) expect it to be "/". This diff makes sure that this is the case. Werkzeug maintainers consider this to be an implementation mistake on httpd's side.

Followup discussions:
https://github.com/reyk/httpd/issues/71
https://github.com/pallets/werkzeug/issues/1240

Fixes #71.